### PR TITLE
fix: add missing release scripts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "asyncapi-preview",
-  "version": "0.3.3",
+  "version": "0.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -73,7 +73,8 @@
     "lint": "eslint src --ext ts",
     "test": "",
     "generate:assets": "",
-    "release": "semantic-release"
+    "release": "semantic-release",
+    "bump:version": "npm --no-git-tag-version --allow-same-version version $VERSION"
   },
   "devDependencies": {
     "@asyncapi/react-component": "^1.0.0-next.38",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "asyncapi-preview",
   "displayName": "asyncapi-preview",
   "description": "Preview AsyncAPI documents inside VSCode.",
-  "version": "0.3.3",
+  "version": "0.1.0",
   "icon": "asyncapi-logo.png",
   "galleryBanner": {
     "color": "#4a4a4a",


### PR DESCRIPTION
@ivangsa this is why release to marketplace did not work as it depends on a bump in package.json, that was missing a script

do you see any problem with us resetting versions of the plugin?