### PR TITLE
fix: add read permissions to all workspace folders

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -46,16 +46,22 @@ function isAsyncAPIFile(text: string) {
 }
 
 function openAsyncAPI(context: vscode.ExtensionContext, uri: vscode.Uri) {
+  const localResourceRoots = [
+    vscode.Uri.file(path.dirname(uri.fsPath)),
+    vscode.Uri.joinPath(context.extensionUri, 'dist/node_modules/@asyncapi/react-component/browser/standalone'),
+    vscode.Uri.joinPath(context.extensionUri, 'dist/node_modules/@asyncapi/react-component/styles'),
+  ];
+  if (vscode.workspace.workspaceFolders) {
+    vscode.workspace.workspaceFolders.forEach(folder => {
+      localResourceRoots.push(folder.uri);
+    });
+  }
   const panel: vscode.WebviewPanel =
     openAsyncapiFiles[uri.fsPath] ||
     vscode.window.createWebviewPanel('asyncapi-preview', '', vscode.ViewColumn.Two, {
       enableScripts: true,
       retainContextWhenHidden: true,
-      localResourceRoots: [
-        vscode.Uri.file(path.dirname(uri.fsPath)),
-        vscode.Uri.joinPath(context.extensionUri, 'dist/node_modules/@asyncapi/react-component/browser/standalone'),
-        vscode.Uri.joinPath(context.extensionUri, 'dist/node_modules/@asyncapi/react-component/styles'),
-      ],
+      localResourceRoots,
     });
   panel.title = path.basename(uri.fsPath);
   panel.webview.html = getWebviewContent(context, panel.webview, uri);


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

Fixes permissions issue when referenced files are in different folders of asyncapi.yml file adding all workspace folders to the list of local resources.

**Related issue(s)**
Fixes #96 
<!-- If you refer to a particular issue, provide its number, othewise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->