### PR TITLE
chore: add asyncapi tool info file

### DIFF
--- a/.asyncapi-tool
+++ b/.asyncapi-tool
@@ -1,0 +1,11 @@
+title: asyncapi-preview
+description: |
+  VSCode extension that enables you to:
+    - Preview documentation generated using you AsyncAPI document. It uses AsyncAPI React component under the hood,
+    - Create AsyncAPI documents faster using SmartPaste functionality
+filters:
+    technology:
+        - VSCode
+        - SmartPaste
+    categories:
+        - ide-extension


### PR DESCRIPTION
Adding file based on https://github.com/asyncapi/website/issues/383

tl;dr the idea is that tools list on website will soon work basing not only on manual process, where people manually add their tools to list, but also automated process where people instead of opening a PR to website, will be able to just add a config file to their public repo.