### PR TITLE
fix: return one single file when prompting for AsyncAPI files #146

### DIFF
--- a/src/PreviewWebPanel.ts
+++ b/src/PreviewWebPanel.ts
@@ -62,7 +62,7 @@ async function promptForAsyncapiFile() {
   if (isAsyncAPIFile(vscode.window.activeTextEditor?.document)) {
     return vscode.window.activeTextEditor?.document.uri;
   }
-  return await vscode.window.showOpenDialog({
+  const uris = await vscode.window.showOpenDialog({
     canSelectFiles: true,
     canSelectFolders: false,
     canSelectMany: false,
@@ -71,6 +71,7 @@ async function promptForAsyncapiFile() {
       AsyncAPI: ['yml', 'yaml', 'json'],
     },
   });
+  return uris?.[0];
 }
 
 function getWebviewContent(context: vscode.ExtensionContext, webview: vscode.Webview, asyncapiFile: vscode.Uri) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -28,6 +28,9 @@ export function activate(context: vscode.ExtensionContext) {
       console.log('Reloading asyncapi file', document.uri.fsPath);
       openAsyncAPI(context, document.uri);
     }
+    if (vscode.window.activeTextEditor?.document) {
+      setAsyncAPIPreviewContext(vscode.window.activeTextEditor.document);
+    }
   });
 
 


### PR DESCRIPTION
- `vscode.window.showOpenDialog` returns an array even when canSelectMany is set to false

- sets context to show "AsyncAPI Preview" button on Editor Title Bar when saving new files (that may not been 'asyncapi' files before saving)

closes #146