### PR TITLE
fix: update marketplace related badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Marketplace Version](https://vsmarketplacebadge.apphb.com/version/asyncapi.asyncapi-preview.svg 'Current Release')](https://marketplace.visualstudio.com/items?itemName=asyncapi.asyncapi-preview) [![Marketplace Downloads](https://vsmarketplacebadge.apphb.com/downloads-short/asyncapi.asyncapi-preview.svg 'Current Release')](https://marketplace.visualstudio.com/items?itemName=asyncapi.asyncapi-preview.svg)
+[![Marketplace Version](https://vsmarketplacebadges.dev/version/asyncapi.asyncapi-preview.svg 'Current Release')](https://marketplace.visualstudio.com/items?itemName=asyncapi.asyncapi-preview) [![Marketplace Downloads](https://vsmarketplacebadges.dev/downloads-short/asyncapi.asyncapi-preview.svg 'Current Release')](https://marketplace.visualstudio.com/items?itemName=asyncapi.asyncapi-preview.svg)
 
 # AsyncAPI Preview
 


### PR DESCRIPTION
We need to trigger another release. Good to not do super dummy release. We actually have badges broken in readme and they do not look nice in the marketplace, so good reason to trigger release

Fun fact. After fix they show latest release is `0.4.1` 😄 
![Screenshot 2023-01-12 at 18 47 45](https://user-images.githubusercontent.com/6995927/212141185-614ce083-f4e5-409f-aa51-f2e4b053f6f1.png)




Related to https://github.com/asyncapi/vs-asyncapi-preview/issues/146