### PR TITLE
fix: use latest release pipeline

### DIFF
--- a/.github/workflows/release-to-marketplaces.yml
+++ b/.github/workflows/release-to-marketplaces.yml
@@ -14,17 +14,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: 16
           cache: 'npm'
           cache-dependency-path: '**/package-lock.json'
       - name: Install dependencies
         run: npm ci
       - name: Publish to Open VSX Registry
-        uses: HaaLeo/publish-vscode-extension@v1
+        uses: HaaLeo/publish-vscode-extension@dfe4f6ad46624424fe24cb5bca79839183399045 # v1.4 https://github.com/HaaLeo/publish-vscode-extension/releases/tag/v1.4.0
         with:
           pat: ${{ secrets.OPEN_VSX_TOKEN }}
 
@@ -35,17 +35,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: 16
           cache: 'npm'
           cache-dependency-path: '**/package-lock.json'
       - name: Install dependencies
         run: npm ci
       - name: Publish to Visual Studio Marketplace
-        uses: HaaLeo/publish-vscode-extension@v1
+        uses: HaaLeo/publish-vscode-extension@dfe4f6ad46624424fe24cb5bca79839183399045 # v1.4 https://github.com/HaaLeo/publish-vscode-extension/releases/tag/v1.4.0
         with:
           pat: ${{ secrets.VS_MARKETPLACE_TOKEN }}
           registryUrl: https://marketplace.visualstudio.com

--- a/package.json
+++ b/package.json
@@ -100,14 +100,10 @@
     "lint": "eslint src --ext ts",
     "test": "",
     "generate:assets": "",
-    "release": "semantic-release",
     "bump:version": "npm --no-git-tag-version --allow-same-version version $VERSION"
   },
   "devDependencies": {
     "@asyncapi/react-component": "^1.0.0-next.47",
-    "@semantic-release/commit-analyzer": "^9.0.2",
-    "@semantic-release/github": "8.0.6",
-    "@semantic-release/release-notes-generator": "^10.0.3",
     "@types/glob": "^7.2.0",
     "@types/js-yaml": "^4.0.5",
     "@types/mocha": "^9.1.1",
@@ -117,36 +113,14 @@
     "@typescript-eslint/parser": "^5.21.0",
     "@vscode/test-electron": "^2.1.3",
     "ajv": "^8.11.0",
-    "conventional-changelog-conventionalcommits": "^4.2.3",
     "copy-webpack-plugin": "^10.2.4",
     "eslint": "^8.14.0",
     "genson-js": "0.0.8",
     "glob": "^8.0.1",
     "mocha": "^9.2.2",
-    "semantic-release": "19.0.5",
     "ts-loader": "^9.2.8",
     "typescript": "^4.6.4",
     "webpack": "^5.70.0",
     "webpack-cli": "^4.9.2"
-  },
-  "release": {
-    "branches": [
-      "master"
-    ],
-    "plugins": [
-      [
-        "@semantic-release/commit-analyzer",
-        {
-          "preset": "conventionalcommits"
-        }
-      ],
-      [
-        "@semantic-release/release-notes-generator",
-        {
-          "preset": "conventionalcommits"
-        }
-      ],
-      "@semantic-release/github"
-    ]
   }
 }


### PR DESCRIPTION
resolves https://github.com/asyncapi/vs-asyncapi-preview/issues/180

- updated versions of some actions
- removed old release config

@ivangsa `@asyncapi/react-component` and some other dependencies that are essential for the extension are under `devDependencies` and not `dependencies` - is it intentional? shouldn't that be fixed? 