### PR TITLE
fix: $ref not being rendered correctly

### DIFF
--- a/src/PreviewWebPanel.ts
+++ b/src/PreviewWebPanel.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
+import * as fs from 'fs';
 
 let position : {x:0,y:0} = {
   x: 0,
@@ -105,6 +106,8 @@ function getWebviewContent(context: vscode.ExtensionContext, webview: vscode.Web
   );
   const asyncapiWebviewUri = webview.asWebviewUri(asyncapiFile);
   const asyncapiBasePath = asyncapiWebviewUri.toString().replace('%2B', '+'); // this is loaded by a different library so it requires unescaping the + character
+  const asyncapiContent = fs.readFileSync(asyncapiFile.fsPath, 'utf-8');
+  
   const html = `
   <!DOCTYPE html>
   <html>
@@ -131,11 +134,9 @@ function getWebviewContent(context: vscode.ExtensionContext, webview: vscode.Web
       <script src="${asyncapiComponentJs}"></script>
       <script>
         const vscode = acquireVsCodeApi();
+        const schema = ${JSON.stringify(asyncapiContent)};
         AsyncApiStandalone.render({
-          schema: {
-            url: '${asyncapiWebviewUri}',
-            options: { method: "GET", mode: "cors" },
-          },
+          schema: schema,
           config: {
             show: {
               sidebar: true,


### PR DESCRIPTION
**Description**
Fixes rendering of $ref references in AsyncAPI documents. After extensive debugging and investigation, I identified that the issue stemmed from how the schema was being injected into the AsyncAPI component.

During the testing phase, AsyncAPI documents containing $ref references were not rendering correctly in the VS Code extension, but were working well in our web envs (react-component and studio)

The main issue was the ordering of the definitions i.e, if the definition of operations is done at the last, the component will render properly. Better approach here was to directly first read the file and directly use it in the AsyncApiStandalone.render function instead of fetching it via URI.

**Related issue(s)**
Fixes https://github.com/asyncapi/vs-asyncapi-preview/issues/204 and closes https://github.com/asyncapi/asyncapi-react/issues/913

Testing Screenshots:
<img width="1440" alt="Screenshot 2024-10-15 at 02 37 27" src="https://github.com/user-attachments/assets/928b73c1-4ff6-42fc-811a-9168aba05b5e">
