### PR TITLE
fix: rolling back #240 because introduces this regresion #247

### DIFF
--- a/src/PreviewWebPanel.ts
+++ b/src/PreviewWebPanel.ts
@@ -107,7 +107,7 @@ function getWebviewContent(context: vscode.ExtensionContext, webview: vscode.Web
   const asyncapiWebviewUri = webview.asWebviewUri(asyncapiFile);
   const asyncapiBasePath = asyncapiWebviewUri.toString().replace('%2B', '+'); // this is loaded by a different library so it requires unescaping the + character
   const asyncapiContent = fs.readFileSync(asyncapiFile.fsPath, 'utf-8');
-  
+
   const html = `
   <!DOCTYPE html>
   <html>
@@ -134,9 +134,11 @@ function getWebviewContent(context: vscode.ExtensionContext, webview: vscode.Web
       <script src="${asyncapiComponentJs}"></script>
       <script>
         const vscode = acquireVsCodeApi();
-        const schema = ${JSON.stringify(asyncapiContent)};
         AsyncApiStandalone.render({
-          schema: schema,
+          schema:  {
+            url: '${asyncapiWebviewUri}',
+            options: { method: "GET", mode: "cors" },
+          },
           config: {
             show: {
               sidebar: true,


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

Loading asyncapi schema via file url instead of reading the file directly with `fs` 
Reading the file directly with `fs` loses the folder context so other files are not properly `$ref`erenced

**Related issue(s)**

rolling back #240 because introduces this regresion #247