### PR TITLE
fix(eda): visualizer is hot reloaded

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import { isAsyncAPIFile, openAsyncAPI, openAsyncapiFiles, previewAsyncAPI } from './PreviewWebPanel';
 import { asyncapiSmartPaste } from './SmartPasteCommand';
-import { visualizeAsyncApi } from './Visualizer';
+import { visualizeAsyncApi, openVisualizerFiles } from './Visualizer';
 import { visualizeAsyncApiFocus } from './ApplicationFocusView';
 
 
@@ -33,9 +33,9 @@ export function activate(context: vscode.ExtensionContext) {
     if (vscode.window.activeTextEditor?.document) {
       setAsyncAPIPreviewContext(vscode.window.activeTextEditor.document);
     }
-    if(openAsyncapiFiles[document.uri.fsPath]){
+    if (openVisualizerFiles[document.uri.fsPath]) {
       console.log('Reloading visualizer file', document.uri.fsPath);
-      visualizeAsyncApi(context);
+      visualizeAsyncApi(context)(document.uri);
     }
   });
 


### PR DESCRIPTION
**Description**

- Fixed hot reloading issue in EDA visualizer by properly handling panel updates instead of creating new panels on each save
- Added loading indicator while the visualizer is being reloaded
- Improved error handling during visualizer rendering
- Fixed script loading timing issues by implementing a retry mechanism
- Enhanced user experience with proper loading states and error messages
- Optimized panel management to prevent multiple instances of the same file

**Related issue(s)**
Resolves  #251 
